### PR TITLE
Support Symfony 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.3",
+        "symfony/framework-bundle": "~2.2",
         "akeneo/crowdin-api":       "1.0.*@dev"
     },
     "require-dev": {


### PR DESCRIPTION
Basic usage works with 2.2. Any particular reason why there is a 2.3 requirement?
