### PR TITLE
Parameter definitions have been added

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,6 +12,13 @@
         <parameter key="jjanvier_crowdin.synchronizer.up_synchronizer.class">Jjanvier\Library\Crowdin\Synchronizer\UpSynchronizer</parameter>
         <parameter key="jjanvier_crowdin.translation.finder.class">Jjanvier\Library\Crowdin\Translation\TranslationFinder</parameter>
         <parameter key="jjanvier_crowdin.translation.mapper.class">Jjanvier\Library\Crowdin\Translation\TranslationMapper</parameter>
+
+        <!-- Parameters definitions. Should be overridden by bundle configuration, if needed. -->
+        <parameter key="jjanvier_crowdin.github.username">null</parameter>
+        <parameter key="jjanvier_crowdin.github.email">null</parameter>
+        <parameter key="jjanvier_crowdin.github.token">null</parameter>
+        <parameter key="jjanvier_crowdin.github.organization">null</parameter>
+        <parameter key="jjanvier_crowdin.github.project">null</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
Hi @jjanvier 

We have been using the bundle at commit #1436ffee093c9ccf13abfa7f0c86417f7d09cc26
Trying to upgrade it to latest version met new Sync\* commands, which depend on set of `jjanvier_crowdin.github.*` parameters. These params are created from `github` section of the bundle config.
And since we don't use them, we have to fill this config section with stubs. Otherwise `Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException` being thrown.
I'm also now allowed to set them to `null` because of bundle `Configuration`.

This pull request allows to keep `config.yml` of the project more neat.
Compare:

``` yml
jjanvier_crowdin:
    crowdin:
        api_key: %crowdin_api_key%
        project_identifier: %crowdin_project_identifier%
    github:
        username: "something_useless"
        email: "something_useless"
        token: "something_useless"
        organization: "something_useless"
        project: "something_useless"
```

And:

``` yml
jjanvier_crowdin:
    crowdin:
        api_key: %crowdin_api_key%
        project_identifier: %crowdin_project_identifier%
```

Thanks in advance
